### PR TITLE
Lazy dirtyfields

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -4,8 +4,7 @@ from django.db.models.signals import post_save
 
 
 class DirtyFieldsMixin(object):
-    def __init__(self, *args, **kwargs):
-        super(DirtyFieldsMixin, self).__init__(*args, **kwargs)
+    def edit(self):
         post_save.connect(
             reset_state, sender=self.__class__,
             dispatch_uid='{name}-DirtyFieldsMixin-sweeper'.format(


### PR DESCRIPTION
Dirty fields will be available after edit() call.

No overhead on ready-only usage.
Call edit() before updating fields.